### PR TITLE
2.2074 port and fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,2 +1,7 @@
+# 2.0.0 (by user95401)
+- Update to v4 of SDK (Geometry Dash 2.2074)
+- Freed from Node IDs dependence
+- Better way to make offset
+
 # 1.0.0
 - Initial commit

--- a/mod.json
+++ b/mod.json
@@ -1,25 +1,17 @@
 {
-	"geode": "3.3.0",
+	"geode": "4.0.1",
 	"gd": {
-		"win": "2.206",
-		"android": "2.206",
-		"mac": "2.206",
-		"ios": "2.206"
+		"win": "2.2074",
+		"android": "2.2074",
+		"mac": "2.2074",
+		"ios": "2.2074"
 	},
-	"platform": ["win", "android", "mac"],
 	"id": "jecket.gauntlets_position_fix",
 	"name": "Gauntlets Position Fix",
-	"version": "v1.0.0",
+	"version": "v2.0.0",
 	"developer": "Jecket",
 	"description": "Fixes the positioning for Gauntlet entries.",
 	"repository": "https://github.com/MathieuAR-GDPSFH/Gauntlets-Position-Fix",
-	"dependencies": [
-        {
-            "id": "geode.node-ids",
-            "version": ">=v1.13.1",
-            "importance": "required"
-        }
-	],
 	"tags": [
 		"bugfix"
 	]

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,23 +1,17 @@
 #include <Geode/Geode.hpp>
-#include <Geode/modify/GauntletSelectLayer.hpp>
 using namespace geode::prelude;
-class $modify(GauntletSelectLayer) {
-    bool init(int gt) {
-        return GauntletSelectLayer::init(gt);
-    }
 
-    void setupGauntlets() {
+#include <Geode/modify/GauntletSelectLayer.hpp>//why u guys move this on top ever? - user95401
+class $modify(GauntletSelectLayerFix, GauntletSelectLayer) {
+    $override void setupGauntlets() {
         GauntletSelectLayer::setupGauntlets();
-
-        auto list = this->getChildByIDRecursive("gauntlets-list");
-        if (!list) return;
-
-        auto pages = typeinfo_cast<CCArray*>(list->getChildByID("gauntlet-pages")->getChildren());
-        if (pages->count() == 0) return;
-
-        auto page = typeinfo_cast<CCMenu*>(typeinfo_cast<CCLayer*>(pages->objectAtIndex(0))->getChildren()->objectAtIndex(0));
-        if (pages->count() == 1) {
-            page->setPosition({-285.f, page->getPosition().y});
-        }
-    }
+        findFirstChildRecursive<ExtendedLayer>(this,
+            [](ExtendedLayer* gauntlet_pages) {
+                if (gauntlet_pages->getChildrenCount() > 1) return false;
+                gauntlet_pages->setAnchorPoint(CCPointMake(1.f, 0.f));
+                gauntlet_pages->ignoreAnchorPointForPosition(false);
+                return true;
+            }
+        );
+    };
 };


### PR DESCRIPTION
- Update to v4 of SDK (Geometry Dash 2.2074)
- Freed from Node IDs dependence
- Better way to make offset

here is a release of update to try https://github.com/user95401/Gauntlets-Position-Fix/releases/tag/2.0.0